### PR TITLE
Suggested changes for pimatic 0.9 readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "r-pi-usonic": "~2.5.0"
   },
   "peerDependencies": {
-    "pimatic": "0.8.*"
+    "pimatic": ">=0.8.0 <1.0.0"
   },
   "engines": {
     "node": ">0.8.x",

--- a/ultrasonic.coffee
+++ b/ultrasonic.coffee
@@ -35,18 +35,18 @@ module.exports = (env) ->
       return
 
     constructor: (@config) ->
-      @id = config.id
-      @name = config.name
-      @echo = config.echo
-      @trigger = config.trigger
-      @timeout = config.timeout
-      @delay = config.delay
-      @sample = config.sample
-      @interval = config.interval
-      if config.displayUnit?
+      @id = @config.id
+      @name = @config.name
+      @echo = @config.echo
+      @trigger = @config.trigger
+      @timeout = @config.timeout
+      @delay = @config.delay
+      @sample = @config.sample
+      @interval = @config.interval
+      if @config.displayUnit?
         # only change the attributes for this device:
         @attributes = _.cloneDeep(@attributes)
-        @attributes.distance.displayUnit = config.displayUnit
+        @attributes.distance.displayUnit = @config.displayUnit
       super()
 
       @requestValue()


### PR DESCRIPTION
Changes are backward compatible with v0.8. Note, beyond, when I tested with pimatic 0.9 creating a device caused pimatic to run in to a kind of deadlock. Is usonic.createSensor() synchronous? May be you have some time to investigate further with v0.9. This will be great!
